### PR TITLE
Update skm.py

### DIFF
--- a/Source/Python/utils/skm.py
+++ b/Source/Python/utils/skm.py
@@ -2,6 +2,7 @@ import aes
 import os
 import hashlib
 import json
+import urllib
 
 KEKID_CONSTANT_1 = "KEKID_1"
 
@@ -149,7 +150,7 @@ def ResolveKey(options, spec):
         kid = spec_params['kid']
         if '?' in base_url:
             (base_url_path, base_url_query) = tuple(base_url.split('?', 1))
-            base_url_query = '?'+base_url_query
+            base_url_query = '?'+urllib.unquote(base_url_query).decode('utf8')
         else:
             base_url_path = base_url
             base_url_query = ''


### PR DESCRIPTION
DRM service providers like ExpressPlay SKM have customerAuthenticator Token which has "," as part of token so when passing skm parameters to "--encryption-key=" splits part of token which results into 403 Access Denied. 

So, added urldecode so as to safely decode the token with "," to fetch key from SKM

